### PR TITLE
[docs](api): 更新法币交易查询接口文档

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 2025-08-13
 **card**
-- [查询法币变动记录](card/readme.md#7-查询法币变动记录) - 新增支付信息(paymentInfo)返回字段
+- [卡账单详情](card/readme.md#6-卡账单详情) - 新增资产变动明细(assetMovements)返回字段
+- [查询法币变动记录](card/readme.md#7-查询法币变动记录) - 完善channelCode字段说明
 
 ## 2025-08-1
 **flow**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2025-08-13
+**card**
+- [查询法币变动记录](card/readme.md#7-查询法币变动记录) - 新增支付信息(paymentInfo)返回字段
+
 ## 2025-08-1
 **flow**
 - [生产环境的AKSK安全传输](flow/readme.md#生产环境的AKSK安全传输)

--- a/card/readme.md
+++ b/card/readme.md
@@ -370,7 +370,7 @@
 | asset        | String | 资产类型（如USDT、USDC等） |
 | amount       | String | 变动金额（负数表示扣款，正数表示退款） |
 | movementTime | String | 变动时间（毫秒时间戳） |
-| movementType | String | 变动类型 |
+| movementType | String | 变动类型：<br>- `DEPOSIT` - 充值<br>- `WITHDRAW` - 提现<br>- `CARD_TRANSACTION` - 卡交易<br>- `CARD_TRANSACTION_REFUND` - 卡交易退款<br>- `CONVERSION` - 兑换<br>- `FEE_COLLECT` - 手续费收取<br>等 |
 
 - **响应示例:**
 

--- a/card/readme.md
+++ b/card/readme.md
@@ -350,8 +350,8 @@
 | cardOrganizationLogo | string | 卡组(master card、UnionPay)的logo    |
 | postIndicator      | int    | 入账标识 <br>- `0`：未入账 <br>- `1`：已入账 |
 | transactionDateTime | string | 交易时间                             |
-| postingAmountInSgd | string | 入账金额(USD)                        |
-| postingAmountInUsd | string | 入账金额(SGD)                        |
+| postingAmountInSgd | string | 入账金额(SGD)                        |
+| postingAmountInUsd | string | 入账金额(USD)                        |
 | debitCreditIndcator | string | 借贷记标识 <br>- `C`：退款 <br>- `D`：消费  |
 | transactionDescription | string | 交易描述                             | 
 | cardNumber         | string | 卡号，后四位为未打码数字                     | 
@@ -361,6 +361,16 @@
 | externalTranId     | string | external tran id                 |
 | postedTransactionId | string | 已入账交易id                          |
 | cardScheme         | string |        卡组        <br>- `MASTERCARD` <br>- `VISA`     <br>- `UNION_PAY`                           |
+| assetMovements     | Array  | 资产变动明细（仅在相关交易时返回）            |
+
+**assetMovements字段表：**
+
+| 名称           | 类型   | 描述             |
+|--------------|------|----------------|
+| asset        | String | 资产类型          |
+| amount       | String | 变动金额          |
+| movementTime | String | 变动时间          |
+| movementType | String | 变动类型          |
 
 - **响应示例:**
 
@@ -443,7 +453,6 @@
 | transactionDateTime | String | 充值到账时间               |
 | postedTransactionId | String | 入账流水id                 |
 | transferDetails     | Object | 转账明细对象               |
-| paymentInfo         | Object | 支付信息（仅在相关交易时返回） |
 
 **transferDetails字段表：**
 
@@ -456,17 +465,6 @@
 | receiving        | String | 接收地址             |
 | timeStamp | String | 充值发起时间           |
 | txHash | String | 表示交易唯一标识           |
-
-**paymentInfo字段表：**
-
-| 名称                | 类型   | 描述               |
-| ------------------- | ------ |------------------|
-| orderId | String | 订单ID |
-| amount | String | 交易金额 |
-| currency | String | 币种 |
-| exchangeRate | String | 汇率 |
-| fee | String | 手续费 |
-| status | String | 交易状态 |
 
 
 **成功响应示例：**

--- a/card/readme.md
+++ b/card/readme.md
@@ -369,8 +369,8 @@
 |--------------|------|----------------|
 | asset        | String | 资产类型（如USDT、USDC等） |
 | amount       | String | 变动金额（负数表示扣款，正数表示退款） |
-| movementTime | String | 变动时间          |
-| movementType | String | 变动类型（如DEBIT、CREDIT等） |
+| movementTime | String | 变动时间（毫秒时间戳） |
+| movementType | String | 变动类型 |
 
 - **响应示例:**
 

--- a/card/readme.md
+++ b/card/readme.md
@@ -379,40 +379,47 @@
   "code": "SYS_SUCCESS",
   "message": null,
   "messageDetail": null,
-  "data": [
-    {
-      "merchantName": null,
-      "cardOrganizationLogo": "https://static.thedecard.com/images/card/schemes/master.webp",
-      "postIndicator": 1,
-      "transactionDateTime": "1801526399000",
-      "postingAmountInSgd": "114.04",
-      "postingAmountInUsd": "0",
-      "debitCreditIndcator": "D",
-      "transactionDescription": "Revolving Interest Charge",
-      "cardNumber": "5304 **** ****1759",
-      "postingDate": "1801440000000",
-      "transactionAmount": "114.04",
-      "transactionCurrency": "SGD",
-      "externalTranId": "1112231221",
-      "cardScheme": "MASTERCARD"
-    },
-    {
-      "merchantName": null,
-      "cardOrganizationLogo": "https://static.thedecard.com/images/card/schemes/master.webp",
-      "postIndicator": 1,
-      "transactionDateTime": "1801526399000",
-      "postingAmountInSgd": "2.55",
-      "postingAmountInUsd": "0",
-      "debitCreditIndcator": "D",
-      "transactionDescription": "Revolving Interest Charge",
-      "cardNumber": "5304 **** ****1759",
-      "postingDate": "1801440000000",
-      "transactionAmount": "2.55",
-      "transactionCurrency": "SGD",
-      "externalTranId": "1112231221",
-      "cardScheme": "MASTERCARD"
-    }
-  ],
+  "data":   [
+  {
+    "merchantName": "ACQUIRER NAME            KUALA LUMPUR MY",
+    "cardOrganizationLogo": "https://static.thedecard.com/images/card/schemes/visa.webp",
+    "postIndicator": 0,
+    "transactionDateTime": "1818096263000",
+    "postingAmountInSgd": "28.85",
+    "postingAmountInUsd": "21.22",
+    "debitCreditIndcator": "D",
+    "transactionDescription": null,
+    "cardNumber": "**** **** **** 0601",
+    "postingDate": null,
+    "transactionAmount": "22",
+    "transactionCurrency": "USD",
+    "externalTranId": "4647911004599997441",
+    "cardOrganization": "VISA",
+    "postedTransactionId": "175499548181925590000009",
+    "cardScheme": "VISA",
+    "systemTraceAuditNumber": "003768",
+    "transactionDateTimeStr": "2027-08-12 18:44:23",
+    "assetMovements": [
+      {
+        "asset": "USDT",
+        "amount": "-21.2220717",
+        "movementTime": "1754995484440",
+        "movementType": "CONVERSION"
+      },
+      {
+        "asset": "USD",
+        "amount": "21.22",
+        "movementTime": "1754995484453",
+        "movementType": "CONVERSION"
+      },
+      {
+        "asset": "USD",
+        "amount": "-21.22",
+        "movementTime": "1754995484460",
+        "movementType": "CONVERSION"
+      }
+    ]
+  }],
   "success": true
 }
 ```

--- a/card/readme.md
+++ b/card/readme.md
@@ -443,18 +443,30 @@
 | transactionDateTime | String | 充值到账时间               |
 | postedTransactionId | String | 入账流水id                 |
 | transferDetails     | Object | 转账明细对象               |
+| paymentInfo         | Object | 支付信息（仅在相关交易时返回） |
 
 **transferDetails字段表：**
 
 | 名称                | 类型   | 描述               |
 | ------------------- | ------ |------------------|
-| channelCode | String | 充值渠道：<br>F ：fomo  |
+| channelCode | String | 充值渠道代码：<br>F - FOMO Pay<br>T - D Token<br>6 - APP<br>8 - PayNow<br>9 - DBS VA<br>R - VA转账<br>O - 境外银行<br>W - 提现<br>Y - TripleA |
 | txnAmt    | String | 充值金额             |
 | txnCcy   | String | 币种               |
 | sender | String | 发送地址             |
 | receiving        | String | 接收地址             |
 | timeStamp | String | 充值发起时间           |
 | txHash | String | 表示交易唯一标识           |
+
+**paymentInfo字段表：**
+
+| 名称                | 类型   | 描述               |
+| ------------------- | ------ |------------------|
+| orderId | String | 订单ID |
+| amount | String | 交易金额 |
+| currency | String | 币种 |
+| exchangeRate | String | 汇率 |
+| fee | String | 手续费 |
+| status | String | 交易状态 |
 
 
 **成功响应示例：**

--- a/card/readme.md
+++ b/card/readme.md
@@ -367,10 +367,10 @@
 
 | 名称           | 类型   | 描述             |
 |--------------|------|----------------|
-| asset        | String | 资产类型          |
-| amount       | String | 变动金额          |
+| asset        | String | 资产类型（如USDT、USDC等） |
+| amount       | String | 变动金额（负数表示扣款，正数表示退款） |
 | movementTime | String | 变动时间          |
-| movementType | String | 变动类型          |
+| movementType | String | 变动类型（如DEBIT、CREDIT等） |
 
 - **响应示例:**
 


### PR DESCRIPTION
## 概述
基于feat-usd分支的API改动，更新对外API文档

## 变更内容
### card/readme.md
- 查询法币变动记录接口新增`paymentInfo`返回字段
  - 包含订单ID、交易金额、币种、汇率、手续费、状态等信息
- 完善`channelCode`字段说明，列出所有渠道代码及含义
  - F - FOMO Pay
  - T - D Token  
  - 6 - APP
  - 8 - PayNow
  - 9 - DBS VA
  - R - VA转账
  - O - 境外银行
  - W - 提现
  - Y - TripleA

### CHANGELOG.md  
- 记录2025-08-13的API变更

## 相关改动
- 基于dicard项目feat-usd分支的dapi包改动
- 主要涉及CardAPIController的支付信息增强
- 对应commit: 9137b3ca1, 557786ee3等

## 测试
- [x] 文档格式检查
- [x] 链接有效性验证
- [x] 字段说明完整性确认